### PR TITLE
Comparison of Initialization vs Isometry in Qiskit

### DIFF
--- a/labs/202 Initialisation vs Isometry analysis.ipynb
+++ b/labs/202 Initialisation vs Isometry analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "5a05b98a",
+   "id": "e93ecf87",
    "metadata": {},
    "source": [
     "# Initialization vs Isometry in Qiskit"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c60386f2",
+   "id": "94334142",
    "metadata": {},
    "source": [
     "According to `201 Tips and tricks.ipynb` there are exist two approaches to prepare the state: one was proposed by Shende, Bullock and Markov in [\"Synthesis of Quantum Logic Circuits\"](https://arxiv.org/abs/quant-ph/0406176) (2004) and another — by Iten et al. in [\"Quantum Circuits for Isometries\"](https://arxiv.org/abs/1501.06911) (2020). For more details please refer to correspondent notebook and original papers.\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "498198a5",
+   "id": "f802efe3",
    "metadata": {},
    "source": [
     "### 0. Prerequisites"
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "66c37b39",
+   "id": "cfeaeaa3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ce5d95a",
+   "id": "b29e33de",
    "metadata": {},
    "source": [
     "### 1. Metrics"
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "98fdebec",
+   "id": "9d8b7366",
    "metadata": {},
    "source": [
     "Let's construct a class that will examine how emperical distribution is close to an input vector. Since, we operate with arrays of numbers of a fixed length, we can consider them both as distributions and as vectors. Methods will be assessed in terms of [mean-absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error), [Wasserstein metric](https://en.wikipedia.org/wiki/Wasserstein_metric) — minimal amount of work to transform one distribution into another, and [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity) — measure of how orientation and direction of vectors is close."
@@ -67,7 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "94479103",
+   "id": "d1748c34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe43bc58",
+   "id": "4e24e383",
    "metadata": {},
    "source": [
     "### 2. Baсkends"
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d220fa54",
+   "id": "34d9a2e3",
    "metadata": {},
    "source": [
     "Experiments will be conducted both in simulators and on a QPU. Thus, it makes sense to create a separate class that \"unifies\" creation of new backend objects."
@@ -105,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "2053a94b",
+   "id": "3e1e8d44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "a9b6c1ca",
+   "id": "66de871f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "ee8accdd",
+   "id": "1ce0be98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "9d44f5fa",
+   "id": "353d0036",
    "metadata": {},
    "outputs": [
     {
@@ -173,16 +173,16 @@
      "output_type": "stream",
      "text": [
       "ibmq_qasm_simulator\t is online=True\twith a queue=2\n",
-      "ibmq_lima\t is online=True\twith a queue=370\n",
-      "ibmq_belem\t is online=True\twith a queue=160\n",
-      "ibmq_quito\t is online=True\twith a queue=27\n",
+      "ibmq_lima\t is online=True\twith a queue=372\n",
+      "ibmq_belem\t is online=True\twith a queue=167\n",
+      "ibmq_quito\t is online=True\twith a queue=6\n",
       "simulator_statevector\t is online=True\twith a queue=2\n",
-      "simulator_mps\t is online=True\twith a queue=3\n",
-      "simulator_extended_stabilizer\t is online=True\twith a queue=3\n",
+      "simulator_mps\t is online=True\twith a queue=2\n",
+      "simulator_extended_stabilizer\t is online=True\twith a queue=2\n",
       "simulator_stabilizer\t is online=True\twith a queue=2\n",
-      "ibmq_manila\t is online=True\twith a queue=119\n",
-      "ibm_nairobi\t is online=True\twith a queue=510\n",
-      "ibm_oslo\t is online=True\twith a queue=260\n"
+      "ibmq_manila\t is online=True\twith a queue=156\n",
+      "ibm_nairobi\t is online=True\twith a queue=514\n",
+      "ibm_oslo\t is online=True\twith a queue=271\n"
      ]
     }
    ],
@@ -198,7 +198,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4eaa1e82",
+   "id": "82b1b536",
+   "metadata": {},
+   "source": [
+    "You can check status of the job [here](https://quantum-computing.ibm.com/jobs)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62260c7f",
    "metadata": {},
    "source": [
     "### 3. Design single experiment"
@@ -206,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a0d1259",
+   "id": "48617674",
    "metadata": {},
    "source": [
     "Our experiment consists of several stages: \n",
@@ -220,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "4e3c3573",
+   "id": "77ad2899",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "c76d7a07",
+   "id": "952c9ef4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +313,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e0346af",
+   "id": "46358889",
    "metadata": {},
    "source": [
     "Let's run experiments both in simulator and QPU for sanity checking."
@@ -314,26 +322,26 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "eab7b0ec",
+   "id": "82df9ec6",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  2.76it/s]\n"
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  2.68it/s]\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[{'initialize': {'mae': 0.04253919412604212,\n",
-       "   'wasserstein': 0.04253919412604211,\n",
-       "   'cosine_similarity': 0.9634270634527289,\n",
+       "[{'initialize': {'mae': 0.03819196067887481,\n",
+       "   'wasserstein': 0.03819196067887481,\n",
+       "   'cosine_similarity': 0.9709690437661644,\n",
        "   'n_gates': 30},\n",
-       "  'isometry': {'mae': 0.043300179474010624,\n",
-       "   'wasserstein': 0.043300179474010624,\n",
-       "   'cosine_similarity': 0.9628786100813833,\n",
+       "  'isometry': {'mae': 0.03777557243896339,\n",
+       "   'wasserstein': 0.0377755724389634,\n",
+       "   'cosine_similarity': 0.9711656966602549,\n",
        "   'n_gates': 26}}]"
       ]
      },
@@ -349,7 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "de5f2c06",
+   "id": "84326e8a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,16 +371,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "90a230c3",
+   "execution_count": 11,
+   "id": "35693418",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|                                                                                                              | 0/1 [00:00<?, ?it/s]"
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [04:16<00:00, 256.22s/it]\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'initialize': {'mae': 0.05519181540477344,\n",
+       "   'wasserstein': 0.03050661805981815,\n",
+       "   'cosine_similarity': 0.9263767686992426,\n",
+       "   'n_gates': 77},\n",
+       "  'isometry': {'mae': 0.059142501197201255,\n",
+       "   'wasserstein': 0.030878333120109413,\n",
+       "   'cosine_similarity': 0.9117006440549178,\n",
+       "   'n_gates': 56}}]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -381,7 +406,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54a4f7ee",
+   "id": "eb6e3475",
    "metadata": {},
    "source": [
     "### 4. Analyse multiple experiments"
@@ -389,7 +414,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dbfe4f17",
+   "id": "2f4c4d88",
    "metadata": {},
    "source": [
     "Processes in quantum computations are stochastic. So, in order to draw any conclusions, we should (at least try to) conduct multiple experiments. Frankly speaking, we might want to run experiments until the vector averaged over all iterations converges. The bad thing is that I don't have my own QPU yet :( , so we will wait a lot in a queue. Also, this approach inherits problems with floating-point arithmetic. Therefore, let the number of iterations (=experiments) be fixed."
@@ -397,8 +422,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "7f056b7f",
+   "execution_count": 12,
+   "id": "f90213af",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,8 +460,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "3047bbf2",
+   "execution_count": 13,
+   "id": "7f0b5751",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,15 +470,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "64c1ffbe",
+   "execution_count": 14,
+   "id": "a803a049",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  2.74it/s]"
+      "100%|████████████████████████████████████████████████████████████████████████████████████████████████| 1000/1000 [05:57<00:00,  2.80it/s]"
      ]
     },
     {
@@ -462,14 +487,14 @@
      "text": [
       "Backend: qasm_simulator\n",
       "  'qc.initialise':\n",
-      "\tmae: 0.04218623 ± 0.00000042\n",
-      "\twasserstein: 0.04218623 ± 0.00000042\n",
-      "\tcosine_similarity: 0.96248341 ± 0.00000189\n",
+      "\tmae: 0.04347118 ± 0.00000022\n",
+      "\twasserstein: 0.04347107 ± 0.00000022\n",
+      "\tcosine_similarity: 0.96350168 ± 0.00000057\n",
       "\tn_gates: 30.00000000 ± 0.00000000\n",
       "  'qc.isometry':\n",
-      "\tmae: 0.04186775 ± 0.00000043\n",
-      "\twasserstein: 0.04186775 ± 0.00000043\n",
-      "\tcosine_similarity: 0.96275767 ± 0.00000070\n",
+      "\tmae: 0.04347910 ± 0.00000025\n",
+      "\twasserstein: 0.04347907 ± 0.00000025\n",
+      "\tcosine_similarity: 0.96347720 ± 0.00000068\n",
       "\tn_gates: 26.00000000 ± 0.00000000\n"
      ]
     },
@@ -495,14 +520,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b9f50366",
+   "execution_count": 15,
+   "id": "21505b3c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [36:02<00:00, 216.26s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Backend: ibmq_quito\n",
+      "  'qc.initialise':\n",
+      "\tmae: 0.07594956 ± 0.00008863\n",
+      "\twasserstein: 0.04050669 ± 0.00003384\n",
+      "\tcosine_similarity: 0.85887136 ± 0.00134992\n",
+      "\tn_gates: 68.30000000 ± 28.61000000\n",
+      "  'qc.isometry':\n",
+      "\tmae: 0.06860864 ± 0.00004447\n",
+      "\twasserstein: 0.03987021 ± 0.00002749\n",
+      "\tcosine_similarity: 0.88385328 ± 0.00060818\n",
+      "\tn_gates: 65.00000000 ± 45.00000000\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "experiment_ibm = Experiment(\n",
     "    backend_factory=IBMQpuFactory(name=\"ibmq_quito\"),\n",
-    "    n_repetitions=5,\n",
+    "    n_repetitions=10,\n",
     "    n_qubits=5, \n",
     "    shots=20000 # max. number of shots for ibm-q\n",
     ")\n",
@@ -513,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5280edfd",
+   "id": "1fb51cf1",
    "metadata": {},
    "source": [
     "### Discussion"
@@ -521,7 +578,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cc2c1db4",
+   "id": "e5318ee6",
    "metadata": {},
    "source": [
     "The results show that both methods are of compatible accuracy in terms of MAE, Wasserstein metric and cosine similariy. Although, `.isometry()` gives a slightly better performance. The reason is probably in the lower number of gates used by isometry and consequent better fidelity of an obtained state vector. \n",

--- a/labs/202 Initialisation vs Isometry analysis.ipynb
+++ b/labs/202 Initialisation vs Isometry analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "aefd28cb",
+   "id": "ec75adac",
    "metadata": {},
    "source": [
     "# Initialization vs Isometry in Qiskit"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5fb2351f",
+   "id": "90c2c66c",
    "metadata": {},
    "source": [
     "According to `201 Tips and tricks.ipynb` there are exist two approaches to prepare the state: one was proposed by Shende, Bullock and Markov in [\"Synthesis of Quantum Logic Circuits\"](https://arxiv.org/abs/quant-ph/0406176) (2004) and another — by Iten et al. in [\"Quantum Circuits for Isometries\"](https://arxiv.org/abs/1501.06911) (2020). For more details please refer to correspondent notebook and original papers.\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f8f1f7b",
+   "id": "a471e88e",
    "metadata": {},
    "source": [
     "### 0. Prerequisites"
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "78bb8e79",
+   "id": "54213a57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4bcc410a",
+   "id": "d0c6bd82",
    "metadata": {},
    "source": [
     "### 1. Metrics"
@@ -57,16 +57,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a3c2084",
+   "id": "2cb6f568",
    "metadata": {},
    "source": [
-    "Let's construct a class that will examine how emperical distribution is close to an input vector. Since, we operate with a arrays of numbers of a fixed length, we can consider them both as distributions and as vectors. Methods will be assessed in terms of [mean-absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error), [Wasserstein metric](https://en.wikipedia.org/wiki/Wasserstein_metric) — minimal amount of work to transform one distribution into another, and [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity) — measure of how orientation and direction of vectors is closed."
+    "Let's construct a class that will examine how emperical distribution is close to an input vector. Since, we operate with arrays of numbers of a fixed length, we can consider them both as distributions and as vectors. Methods will be assessed in terms of [mean-absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error), [Wasserstein metric](https://en.wikipedia.org/wiki/Wasserstein_metric) — minimal amount of work to transform one distribution into another, and [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity) — measure of how orientation and direction of vectors is close."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ca374bbe",
+   "id": "8b949269",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,24 +86,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "00609ce6",
+   "id": "23f76ee0",
    "metadata": {},
    "source": [
-    "### 2. Bakends"
+    "### 2. Baсkends"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6c7477ee",
+   "id": "07bbcb45",
    "metadata": {},
    "source": [
-    "Experiments will be conducted both in simulation and on QPU. Thus, it makes sense to create a separate class that \"unifies\" creation of new backend objects."
+    "Experiments will be conducted both in simulators and on a QPU. Thus, it makes sense to create a separate class that \"unifies\" creation of new backend objects."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "3e16c2c7",
+   "id": "4fcffb6d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "62ad9db3",
+   "id": "5179c477",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "1d6543a4",
+   "id": "89851047",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "69625023",
+   "id": "a922aaff",
    "metadata": {},
    "outputs": [
     {
@@ -171,16 +171,16 @@
      "output_type": "stream",
      "text": [
       "ibmq_qasm_simulator\t is online=True\twith a queue=0\n",
-      "ibmq_lima\t is online=True\twith a queue=369\n",
-      "ibmq_belem\t is online=True\twith a queue=193\n",
-      "ibmq_quito\t is online=True\twith a queue=162\n",
+      "ibmq_lima\t is online=True\twith a queue=377\n",
+      "ibmq_belem\t is online=True\twith a queue=202\n",
+      "ibmq_quito\t is online=True\twith a queue=171\n",
       "simulator_statevector\t is online=True\twith a queue=0\n",
       "simulator_mps\t is online=True\twith a queue=0\n",
       "simulator_extended_stabilizer\t is online=True\twith a queue=0\n",
-      "simulator_stabilizer\t is online=True\twith a queue=0\n",
-      "ibmq_manila\t is online=True\twith a queue=169\n",
-      "ibm_nairobi\t is online=True\twith a queue=517\n",
-      "ibm_oslo\t is online=True\twith a queue=272\n"
+      "simulator_stabilizer\t is online=True\twith a queue=1\n",
+      "ibmq_manila\t is online=True\twith a queue=191\n",
+      "ibm_nairobi\t is online=True\twith a queue=529\n",
+      "ibm_oslo\t is online=True\twith a queue=284\n"
      ]
     }
    ],
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4c34450",
+   "id": "70fc3f29",
    "metadata": {},
    "source": [
     "### 3. Design single experiment"
@@ -204,11 +204,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a15288f7",
+   "id": "d880696c",
    "metadata": {},
    "source": [
     "Our experiment consists of several stages: \n",
-    "1. Prepare a random vector o size n\n",
+    "1. Prepare a random vector of size n\n",
     "2. Create two quantum circuits with `.initialize()` and `.isometry()` methods\n",
     "3. Execute quantum circuits\n",
     "4. Measure the resultant distribution\n",
@@ -218,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "5a7e4873",
+   "id": "c7317a2c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "4b34b3ac",
+   "id": "5c4f2358",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f51b3a61",
+   "id": "f7dbd17c",
    "metadata": {},
    "source": [
     "Let's run experiments both in simulator and QPU for sanity checking."
@@ -306,18 +306,18 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "3ceebd62",
+   "id": "d0e20c14",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'initialize': {'mae': 0.03305844983960471,\n",
-       "  'wasserstein': 0.03266759566687652,\n",
-       "  'cosine_similarity': 0.9874957555738519},\n",
-       " 'isometry': {'mae': 0.03630205271243242,\n",
-       "  'wasserstein': 0.03630205271243242,\n",
-       "  'cosine_similarity': 0.9856269918858531}}"
+       "{'initialize': {'mae': 0.055757590567228246,\n",
+       "  'wasserstein': 0.05575759056722823,\n",
+       "  'cosine_similarity': 0.966202672086731},\n",
+       " 'isometry': {'mae': 0.055484976079105366,\n",
+       "  'wasserstein': 0.055484976079105366,\n",
+       "  'cosine_similarity': 0.9663103603715456}}"
       ]
      },
      "execution_count": 9,
@@ -332,7 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "652fea52",
+   "id": "d8ba0d7e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,18 +346,18 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "041e06d9",
+   "id": "0936588a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'initialize': {'mae': 0.03302659681928792,\n",
-       "  'wasserstein': 0.028287252058731387,\n",
-       "  'cosine_similarity': 0.9820865188416839},\n",
-       " 'isometry': {'mae': 0.06614933643196075,\n",
-       "  'wasserstein': 0.06120029739837004,\n",
-       "  'cosine_similarity': 0.9565363554096502}}"
+       "{'initialize': {'mae': 0.06291978821819735,\n",
+       "  'wasserstein': 0.029539683734970634,\n",
+       "  'cosine_similarity': 0.9649380929642835},\n",
+       " 'isometry': {'mae': 0.05961318096877364,\n",
+       "  'wasserstein': 0.01971239250522942,\n",
+       "  'cosine_similarity': 0.9488022841978233}}"
       ]
      },
      "execution_count": 11,
@@ -371,7 +371,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ee83b6c",
+   "id": "9ca11256",
    "metadata": {},
    "source": [
     "### 4. Analyse multiple experiments"
@@ -379,16 +379,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a37d2f5c",
+   "id": "563b63ea",
    "metadata": {},
    "source": [
-    "Processes in quantum computations are stochastic. So, in order to draw any conclusions, we should (at least try to) conduct multiple experiments. Frankly speaking, we might want to run experiments until the vector averaged over all iterations converges. Bad thing is that I don't have my own QPU yet :( , so we will wait a lot in a queue. Also, this approach inherit problems with floating-point arithmetic. Therefore, we will only focus on number of iterations (=experiments)."
+    "Processes in quantum computations are stochastic. So, in order to draw any conclusions, we should (at least try to) conduct multiple experiments. Frankly speaking, we might want to run experiments until the vector averaged over all iterations converges. The bad thing is that I don't have my own QPU yet :( , so we will wait a lot in a queue. Also, this approach inherits problems with floating-point arithmetic. Therefore, let the number of iterations (=experiments) be fixed."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "2282448d",
+   "execution_count": 12,
+   "id": "cc4a144f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +405,6 @@
     "        metrics_dict_init = {m: list() for m in self.metrics_available}\n",
     "        metrics_dict_isom = {m: list() for m in self.metrics_available}\n",
     "        for i in range(self.iterations):\n",
-    "            print(i)\n",
     "            e = Experiment(\n",
     "                backend_factory=self.backend_factory,\n",
     "                n_qubits=self.n_qubits,\n",
@@ -437,7 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "900e4759",
+   "id": "1f11dba8",
    "metadata": {},
    "outputs": [
     {
@@ -446,20 +445,20 @@
      "text": [
       "Backend: qasm_simulator\n",
       "  'qc.initialise':\n",
-      "\tmae: 0.03937070 ± 0.00002271\n",
-      "\twasserstein: 0.03936723 ± 0.00002273\n",
-      "\tcosine_similarity: 0.96855378 ± 0.00004631\n",
+      "\tmae: 0.05587970 ± 0.00009222\n",
+      "\twasserstein: 0.05587898 ± 0.00009223\n",
+      "\tcosine_similarity: 0.96795406 ± 0.00009815\n",
       "  'qc.isometry':\n",
-      "\tmae: 0.03935132 ± 0.00002260\n",
-      "\twasserstein: 0.03934719 ± 0.00002263\n",
-      "\tcosine_similarity: 0.96855801 ± 0.00004630\n"
+      "\tmae: 0.05586049 ± 0.00009154\n",
+      "\twasserstein: 0.05585946 ± 0.00009156\n",
+      "\tcosine_similarity: 0.96799147 ± 0.00009684\n"
      ]
     }
    ],
    "source": [
     "inspector = Inspector(\n",
     "    backend_factory=QASMSimulatorFactory(),\n",
-    "    n_qubits=5, \n",
+    "    n_qubits=4, \n",
     "    shots=65535, \n",
     "    iterations=1000\n",
     ")\n",
@@ -468,31 +467,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4ba6e79a",
+   "execution_count": 14,
+   "id": "6ea45faa",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0\n"
+      "Backend: ibm-q ibmq_belem\n",
+      "  'qc.initialise':\n",
+      "\tmae: 0.06896764 ± 0.00003136\n",
+      "\twasserstein: 0.03948394 ± 0.00002017\n",
+      "\tcosine_similarity: 0.94826798 ± 0.00003582\n",
+      "  'qc.isometry':\n",
+      "\tmae: 0.05802084 ± 0.00005029\n",
+      "\twasserstein: 0.03211527 ± 0.00008146\n",
+      "\tcosine_similarity: 0.95444544 ± 0.00016185\n"
      ]
     }
    ],
    "source": [
     "inspector = Inspector(\n",
     "    backend_factory=IBMQpuFactory(),\n",
-    "    n_qubits=5, \n",
+    "    n_qubits=4, \n",
     "    shots=20000, \n",
-    "    iterations=10\n",
+    "    iterations=5\n",
     ")\n",
     "inspector.run()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dfdb2ad7",
+   "id": "11758373",
    "metadata": {},
    "source": [
     "### Discussion"
@@ -500,12 +507,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9fe6810d",
+   "id": "847c6f2b",
    "metadata": {},
    "source": [
-    "Our results show that both methods are compatible in terms of MAE, Wasserstein metric and cosine similariy. Although, `.isometry()` gives a slightly better result. The reason is probably in the lower number of gates used and consequent beter fidelity of a state vector. \n",
+    "The results show that both methods are of compatible accuracy in terms of MAE, Wasserstein metric and cosine similariy. Although, `.isometry()` gives a slightly better performance. The reason is probably in the lower number of gates used by isometry and consequent better fidelity of an obtained state vector. \n",
     "\n",
-    "Due to the fact that experiments take much time, I did not observe the relationship between number of qubits in use and metrics. Thus, I would assume that there is a linear dependency and results will be the same for lower number of qubits, albeit this is a topic for further study. "
+    "Due to the fact that experiments take much time, I did not observe the relationship between number of qubits in use and accuracy of methods. Thus, I would assume that there is a linear dependency and results will be the same for lower number of qubits, albeit this is a topic for further study. "
    ]
   }
  ],

--- a/labs/202 Initialisation vs Isometry analysis.ipynb
+++ b/labs/202 Initialisation vs Isometry analysis.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a5dd0c63",
+   "metadata": {},
+   "source": [
+    "# Initialization vs Isometry in Qiskit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3b6c287",
+   "metadata": {},
+   "source": [
+    "According to `201 Tips and tricks.ipynb` there are exist two approaches to prepare the state: one was proposed by Shende, Bullock and Markov in [\"Synthesis of Quantum Logic Circuits\"](https://arxiv.org/abs/quant-ph/0406176) (2004) and another — by Iten et al. in [\"Quantum Circuits for Isometries\"](https://arxiv.org/abs/1501.06911) (2020). For more details please refer to correspondent notebook and original papers.\n",
+    "\n",
+    "This notebook concerns comparison of these two methods in terms of how close obtained states are to the desired vector. For someone who knows quantum programming inside out, the answer might appear trivial, but not for me..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f6cc06d",
+   "metadata": {},
+   "source": [
+    "### Prerequisites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9c7a4e57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "import numpy as np\n",
+    "from qiskit import QuantumCircuit, BasicAer, execute, transpile\n",
+    "from scipy.stats import wasserstein_distance as ws"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "501d94bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Experiment:\n",
+    "    \n",
+    "    def __init__(self, vector_size=16):\n",
+    "        message = \"Vector size should be power of 2\"\n",
+    "        assert (vector_size & (vector_size-1) == 0) and vector_size != 0, message\n",
+    "        \n",
+    "        self.vector_size = vector_size\n",
+    "        self.n = math.ceil(math.log(self.vector_size, 2))\n",
+    "        \n",
+    "    def run(self, shots=10000):\n",
+    "        data = self.__get_random_vector()\n",
+    "        init_dict = self.__apply_initalize(data, shots)\n",
+    "        \n",
+    "        result = dict(\n",
+    "            init = init_dict,\n",
+    "        )\n",
+    "        return result\n",
+    "    \n",
+    "    def __apply_initalize(self, data, shots):\n",
+    "        n = self.n\n",
+    "        qc = QuantumCircuit(n, n)\n",
+    "        qc.initialize(data)\n",
+    "        qc.measure(range(n), range(n))\n",
+    "        \n",
+    "        counts = execute(qc, BasicAer.get_backend('qasm_simulator'), shots=shots).result().get_counts()\n",
+    "        # TODO: sometimes number of elements there is less than vector_size (pad)\n",
+    "        dist = np.array([b for a,b in sorted(list(counts.items()), key = lambda x: x[0])]) \n",
+    "        dist = dist / np.linalg.norm(dist)\n",
+    "        \n",
+    "        metrics = dict(\n",
+    "            mse = np.square(data - dist).mean(),\n",
+    "            ws = ws(data, dist)\n",
+    "        )\n",
+    "        return metrics\n",
+    "        \n",
+    "    \n",
+    "    def __get_random_vector(self):\n",
+    "        a = np.random.rand(self.vector_size)\n",
+    "        a = a / np.linalg.norm(a)\n",
+    "        return a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3b3a3ee7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment = Experiment(32)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4bc23cd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'init': {'mse': 0.0016230030811164708, 'ws': 0.03584424375870574}}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "experiment.run()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/labs/202 Initialisation vs Isometry analysis.ipynb
+++ b/labs/202 Initialisation vs Isometry analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ec75adac",
+   "id": "5a05b98a",
    "metadata": {},
    "source": [
     "# Initialization vs Isometry in Qiskit"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90c2c66c",
+   "id": "c60386f2",
    "metadata": {},
    "source": [
     "According to `201 Tips and tricks.ipynb` there are exist two approaches to prepare the state: one was proposed by Shende, Bullock and Markov in [\"Synthesis of Quantum Logic Circuits\"](https://arxiv.org/abs/quant-ph/0406176) (2004) and another — by Iten et al. in [\"Quantum Circuits for Isometries\"](https://arxiv.org/abs/1501.06911) (2020). For more details please refer to correspondent notebook and original papers.\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a471e88e",
+   "id": "498198a5",
    "metadata": {},
    "source": [
     "### 0. Prerequisites"
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "54213a57",
+   "id": "66c37b39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,6 +40,7 @@
     "from scipy.stats import wasserstein_distance as ws\n",
     "from numpy import dot\n",
     "from numpy.linalg import norm\n",
+    "from tqdm import tqdm\n",
     "\n",
     "IBMQ.load_account()\n",
     "\n",
@@ -49,7 +50,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0c6bd82",
+   "id": "9ce5d95a",
    "metadata": {},
    "source": [
     "### 1. Metrics"
@@ -57,7 +58,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cb6f568",
+   "id": "98fdebec",
    "metadata": {},
    "source": [
     "Let's construct a class that will examine how emperical distribution is close to an input vector. Since, we operate with arrays of numbers of a fixed length, we can consider them both as distributions and as vectors. Methods will be assessed in terms of [mean-absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error), [Wasserstein metric](https://en.wikipedia.org/wiki/Wasserstein_metric) — minimal amount of work to transform one distribution into another, and [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity) — measure of how orientation and direction of vectors is close."
@@ -66,27 +67,28 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "8b949269",
+   "id": "94479103",
    "metadata": {},
    "outputs": [],
    "source": [
     "class Metrics:\n",
     "    \n",
     "    def __init__(self):\n",
-    "        self.metrics_available = [\"mae\", \"wasserstein\", \"cosine_similarity\"]\n",
+    "        self.metrics_available = [\"mae\", \"wasserstein\", \"cosine_similarity\", \"n_gates\"]\n",
     "    \n",
-    "    def compute(self, data, dist):\n",
+    "    def compute(self, qc, data, dist):\n",
     "        metrics = dict(\n",
     "            mae = np.abs(data - dist).mean(),\n",
     "            wasserstein = ws(data, dist),\n",
-    "            cosine_similarity = np.dot(data, dist) / (np.linalg.norm(data) * np.linalg.norm(dist))\n",
+    "            cosine_similarity = np.dot(data, dist) / (np.linalg.norm(data) * np.linalg.norm(dist)),\n",
+    "            n_gates = qc.count_ops()['cx']\n",
     "        )\n",
     "        return metrics"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "23f76ee0",
+   "id": "fe43bc58",
    "metadata": {},
    "source": [
     "### 2. Baсkends"
@@ -94,7 +96,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "07bbcb45",
+   "id": "d220fa54",
    "metadata": {},
    "source": [
     "Experiments will be conducted both in simulators and on a QPU. Thus, it makes sense to create a separate class that \"unifies\" creation of new backend objects."
@@ -103,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "4fcffb6d",
+   "id": "2053a94b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "5179c477",
+   "id": "a9b6c1ca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "89851047",
+   "id": "ee8accdd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,24 +165,24 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "a922aaff",
+   "id": "9d44f5fa",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ibmq_qasm_simulator\t is online=True\twith a queue=0\n",
-      "ibmq_lima\t is online=True\twith a queue=377\n",
-      "ibmq_belem\t is online=True\twith a queue=202\n",
-      "ibmq_quito\t is online=True\twith a queue=171\n",
-      "simulator_statevector\t is online=True\twith a queue=0\n",
-      "simulator_mps\t is online=True\twith a queue=0\n",
-      "simulator_extended_stabilizer\t is online=True\twith a queue=0\n",
-      "simulator_stabilizer\t is online=True\twith a queue=1\n",
-      "ibmq_manila\t is online=True\twith a queue=191\n",
-      "ibm_nairobi\t is online=True\twith a queue=529\n",
-      "ibm_oslo\t is online=True\twith a queue=284\n"
+      "ibmq_qasm_simulator\t is online=True\twith a queue=2\n",
+      "ibmq_lima\t is online=True\twith a queue=370\n",
+      "ibmq_belem\t is online=True\twith a queue=160\n",
+      "ibmq_quito\t is online=True\twith a queue=27\n",
+      "simulator_statevector\t is online=True\twith a queue=2\n",
+      "simulator_mps\t is online=True\twith a queue=3\n",
+      "simulator_extended_stabilizer\t is online=True\twith a queue=3\n",
+      "simulator_stabilizer\t is online=True\twith a queue=2\n",
+      "ibmq_manila\t is online=True\twith a queue=119\n",
+      "ibm_nairobi\t is online=True\twith a queue=510\n",
+      "ibm_oslo\t is online=True\twith a queue=260\n"
      ]
     }
    ],
@@ -196,7 +198,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70fc3f29",
+   "id": "4eaa1e82",
    "metadata": {},
    "source": [
     "### 3. Design single experiment"
@@ -204,7 +206,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d880696c",
+   "id": "9a0d1259",
    "metadata": {},
    "source": [
     "Our experiment consists of several stages: \n",
@@ -218,33 +220,38 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "c7317a2c",
+   "id": "4e3c3573",
    "metadata": {},
    "outputs": [],
    "source": [
     "class Experiment:\n",
     "    \n",
-    "    def __init__(self, backend_factory, n_qubits=4, shots=65535):\n",
+    "    def __init__(self, backend_factory, n_repetitions=1, n_qubits=4, shots=65535):\n",
     "        self.backend_factory = backend_factory\n",
-    "        self.n = n_qubits\n",
+    "        self.n_repetitions = n_repetitions\n",
+    "        self.n_qubits = n_qubits\n",
     "        self.vector_size = 2 ** n_qubits\n",
     "        self.shots = shots\n",
+    "        \n",
+    "        self.data = self.__get_random_vector()\n",
     "        self.metrics = Metrics()\n",
     "        \n",
     "    def run(self):\n",
-    "        data = self.__get_random_vector()\n",
-    "        \n",
-    "        init_qc = self.__prepare_initialize_circuit(data)\n",
-    "        isom_qc = self.__prepare_isometry_circuit(data)\n",
+    "        results = list()\n",
+    "        data = self.data\n",
+    "        for rep in tqdm(range(self.n_repetitions)):  \n",
+    "            init_qc = self.__prepare_initialize_circuit(data)\n",
+    "            isom_qc = self.__prepare_isometry_circuit(data)\n",
     "\n",
-    "        result = dict(\n",
-    "            initialize = self.__apply(init_qc, data, self.shots),\n",
-    "            isometry = self.__apply(isom_qc, data, self.shots)\n",
-    "        )\n",
-    "        return result\n",
+    "            result = dict(\n",
+    "                initialize = self.__apply(init_qc, data, self.shots),\n",
+    "                isometry = self.__apply(isom_qc, data, self.shots)\n",
+    "            )\n",
+    "            results.append(result)\n",
+    "        return results\n",
     "    \n",
     "    def __prepare_initialize_circuit(self, data):\n",
-    "        n = self.n\n",
+    "        n = self.n_qubits\n",
     "        range_n = range(n)\n",
     "        qc = QuantumCircuit(n, n)\n",
     "        qc.initialize(data)\n",
@@ -252,7 +259,7 @@
     "        return qc\n",
     "    \n",
     "    def __prepare_isometry_circuit(self, data):\n",
-    "        n = self.n\n",
+    "        n = self.n_qubits\n",
     "        range_n = range(n)\n",
     "        qc = QuantumCircuit(n, n)\n",
     "        qc.isometry(data, list(range_n), None)\n",
@@ -264,7 +271,7 @@
     "        qc = transpile(qc, backend)\n",
     "        counts = execute(qc, backend, shots=shots).result().get_counts()\n",
     "        dist = self.__get_dist(counts)\n",
-    "        metrics = self.metrics.compute(data, dist)\n",
+    "        metrics = self.metrics.compute(qc, data, dist)\n",
     "        return metrics\n",
     "    \n",
     "    def __get_dist(self, counts):\n",
@@ -284,20 +291,21 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "5c4f2358",
+   "id": "c76d7a07",
    "metadata": {},
    "outputs": [],
    "source": [
     "experiment_sim = Experiment(\n",
     "    backend_factory=QASMSimulatorFactory(),\n",
-    "    n_qubits=4, \n",
-    "    shots=10000\n",
+    "    n_repetitions=1,\n",
+    "    n_qubits=5, \n",
+    "    shots=65535\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f7dbd17c",
+   "id": "0e0346af",
    "metadata": {},
    "source": [
     "Let's run experiments both in simulator and QPU for sanity checking."
@@ -306,18 +314,27 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "d0e20c14",
+   "id": "eab7b0ec",
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  2.76it/s]\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "{'initialize': {'mae': 0.055757590567228246,\n",
-       "  'wasserstein': 0.05575759056722823,\n",
-       "  'cosine_similarity': 0.966202672086731},\n",
-       " 'isometry': {'mae': 0.055484976079105366,\n",
-       "  'wasserstein': 0.055484976079105366,\n",
-       "  'cosine_similarity': 0.9663103603715456}}"
+       "[{'initialize': {'mae': 0.04253919412604212,\n",
+       "   'wasserstein': 0.04253919412604211,\n",
+       "   'cosine_similarity': 0.9634270634527289,\n",
+       "   'n_gates': 30},\n",
+       "  'isometry': {'mae': 0.043300179474010624,\n",
+       "   'wasserstein': 0.043300179474010624,\n",
+       "   'cosine_similarity': 0.9628786100813833,\n",
+       "   'n_gates': 26}}]"
       ]
      },
      "execution_count": 9,
@@ -332,37 +349,30 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "d8ba0d7e",
+   "id": "de5f2c06",
    "metadata": {},
    "outputs": [],
    "source": [
     "experiment_ibm = Experiment(\n",
-    "    backend_factory=IBMQpuFactory(),\n",
-    "    n_qubits=4, \n",
+    "    backend_factory=IBMQpuFactory(name=\"ibmq_quito\"),\n",
+    "    n_repetitions=1,\n",
+    "    n_qubits=5, \n",
     "    shots=20000 # max. number of shots for ibm-q\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "0936588a",
+   "execution_count": null,
+   "id": "90a230c3",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "{'initialize': {'mae': 0.06291978821819735,\n",
-       "  'wasserstein': 0.029539683734970634,\n",
-       "  'cosine_similarity': 0.9649380929642835},\n",
-       " 'isometry': {'mae': 0.05961318096877364,\n",
-       "  'wasserstein': 0.01971239250522942,\n",
-       "  'cosine_similarity': 0.9488022841978233}}"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|                                                                                                              | 0/1 [00:00<?, ?it/s]"
+     ]
     }
    ],
    "source": [
@@ -371,7 +381,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ca11256",
+   "id": "54a4f7ee",
    "metadata": {},
    "source": [
     "### 4. Analyse multiple experiments"
@@ -379,7 +389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "563b63ea",
+   "id": "dbfe4f17",
    "metadata": {},
    "source": [
     "Processes in quantum computations are stochastic. So, in order to draw any conclusions, we should (at least try to) conduct multiple experiments. Frankly speaking, we might want to run experiments until the vector averaged over all iterations converges. The bad thing is that I don't have my own QPU yet :( , so we will wait a lot in a queue. Also, this approach inherits problems with floating-point arithmetic. Therefore, let the number of iterations (=experiments) be fixed."
@@ -387,38 +397,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "cc4a144f",
+   "execution_count": 10,
+   "id": "7f056b7f",
    "metadata": {},
    "outputs": [],
    "source": [
     "class Inspector:\n",
     "    \n",
-    "    def __init__(self, backend_factory, n_qubits=4, shots=65535, iterations=100):\n",
-    "        self.backend_factory = backend_factory\n",
-    "        self.n_qubits = n_qubits\n",
-    "        self.shots = shots\n",
-    "        self.iterations = iterations\n",
+    "    def __init__(self):\n",
     "        self.metrics_available = Metrics().metrics_available\n",
     "    \n",
-    "    def run(self):\n",
+    "    def run(self, results, name):\n",
     "        metrics_dict_init = {m: list() for m in self.metrics_available}\n",
     "        metrics_dict_isom = {m: list() for m in self.metrics_available}\n",
-    "        for i in range(self.iterations):\n",
-    "            e = Experiment(\n",
-    "                backend_factory=self.backend_factory,\n",
-    "                n_qubits=self.n_qubits,\n",
-    "                shots=self.shots\n",
-    "            )\n",
-    "            e = e.run()\n",
-    "            \n",
-    "            for m, v in e[\"initialize\"].items():\n",
+    "        \n",
+    "        for result in results:\n",
+    "            for m, v in result[\"initialize\"].items():\n",
     "                metrics_dict_init[m].append(v)\n",
-    "                \n",
-    "            for m, v in e[\"isometry\"].items():\n",
+    "               \n",
+    "            for m, v in result[\"isometry\"].items():\n",
     "                metrics_dict_isom[m].append(v)\n",
     "        \n",
-    "        print(f\"Backend: {self.backend_factory}\")\n",
+    "        print(f\"Backend: {name}\")\n",
     "        \n",
     "        print(\"  'qc.initialise':\")\n",
     "        for m, v in metrics_dict_init.items():\n",
@@ -435,71 +435,85 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "1f11dba8",
+   "execution_count": 11,
+   "id": "3047bbf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inspector = Inspector()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "64c1ffbe",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  2.74it/s]"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Backend: qasm_simulator\n",
       "  'qc.initialise':\n",
-      "\tmae: 0.05587970 ± 0.00009222\n",
-      "\twasserstein: 0.05587898 ± 0.00009223\n",
-      "\tcosine_similarity: 0.96795406 ± 0.00009815\n",
+      "\tmae: 0.04218623 ± 0.00000042\n",
+      "\twasserstein: 0.04218623 ± 0.00000042\n",
+      "\tcosine_similarity: 0.96248341 ± 0.00000189\n",
+      "\tn_gates: 30.00000000 ± 0.00000000\n",
       "  'qc.isometry':\n",
-      "\tmae: 0.05586049 ± 0.00009154\n",
-      "\twasserstein: 0.05585946 ± 0.00009156\n",
-      "\tcosine_similarity: 0.96799147 ± 0.00009684\n"
+      "\tmae: 0.04186775 ± 0.00000043\n",
+      "\twasserstein: 0.04186775 ± 0.00000043\n",
+      "\tcosine_similarity: 0.96275767 ± 0.00000070\n",
+      "\tn_gates: 26.00000000 ± 0.00000000\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
    "source": [
-    "inspector = Inspector(\n",
+    "experiment_sim = Experiment(\n",
     "    backend_factory=QASMSimulatorFactory(),\n",
-    "    n_qubits=4, \n",
-    "    shots=65535, \n",
-    "    iterations=1000\n",
+    "    n_repetitions=1000,\n",
+    "    n_qubits=5, \n",
+    "    shots=65535\n",
     ")\n",
-    "inspector.run()"
+    "\n",
+    "results_sim = experiment_sim.run()\n",
+    "inspector.run(results_sim, \"qasm_simulator\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "6ea45faa",
+   "execution_count": null,
+   "id": "b9f50366",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Backend: ibm-q ibmq_belem\n",
-      "  'qc.initialise':\n",
-      "\tmae: 0.06896764 ± 0.00003136\n",
-      "\twasserstein: 0.03948394 ± 0.00002017\n",
-      "\tcosine_similarity: 0.94826798 ± 0.00003582\n",
-      "  'qc.isometry':\n",
-      "\tmae: 0.05802084 ± 0.00005029\n",
-      "\twasserstein: 0.03211527 ± 0.00008146\n",
-      "\tcosine_similarity: 0.95444544 ± 0.00016185\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "inspector = Inspector(\n",
-    "    backend_factory=IBMQpuFactory(),\n",
-    "    n_qubits=4, \n",
-    "    shots=20000, \n",
-    "    iterations=5\n",
+    "experiment_ibm = Experiment(\n",
+    "    backend_factory=IBMQpuFactory(name=\"ibmq_quito\"),\n",
+    "    n_repetitions=5,\n",
+    "    n_qubits=5, \n",
+    "    shots=20000 # max. number of shots for ibm-q\n",
     ")\n",
-    "inspector.run()"
+    "\n",
+    "results_ibm = experiment_ibm.run()\n",
+    "inspector.run(results_ibm, \"ibmq_quito\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "11758373",
+   "id": "5280edfd",
    "metadata": {},
    "source": [
     "### Discussion"
@@ -507,7 +521,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "847c6f2b",
+   "id": "cc2c1db4",
    "metadata": {},
    "source": [
     "The results show that both methods are of compatible accuracy in terms of MAE, Wasserstein metric and cosine similariy. Although, `.isometry()` gives a slightly better performance. The reason is probably in the lower number of gates used by isometry and consequent better fidelity of an obtained state vector. \n",

--- a/labs/202 Initialisation vs Isometry analysis.ipynb
+++ b/labs/202 Initialisation vs Isometry analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b236a439",
+   "id": "aefd28cb",
    "metadata": {},
    "source": [
     "# Initialization vs Isometry in Qiskit"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12e3b3b8",
+   "id": "5fb2351f",
    "metadata": {},
    "source": [
     "According to `201 Tips and tricks.ipynb` there are exist two approaches to prepare the state: one was proposed by Shende, Bullock and Markov in [\"Synthesis of Quantum Logic Circuits\"](https://arxiv.org/abs/quant-ph/0406176) (2004) and another — by Iten et al. in [\"Quantum Circuits for Isometries\"](https://arxiv.org/abs/1501.06911) (2020). For more details please refer to correspondent notebook and original papers.\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3f79a3a",
+   "id": "4f8f1f7b",
    "metadata": {},
    "source": [
     "### 0. Prerequisites"
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "30cf9e38",
+   "id": "78bb8e79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1dc83d7d",
+   "id": "4bcc410a",
    "metadata": {},
    "source": [
     "### 1. Metrics"
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1758cdad",
+   "id": "7a3c2084",
    "metadata": {},
    "source": [
     "Let's construct a class that will examine how emperical distribution is close to an input vector. Since, we operate with a arrays of numbers of a fixed length, we can consider them both as distributions and as vectors. Methods will be assessed in terms of [mean-absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error), [Wasserstein metric](https://en.wikipedia.org/wiki/Wasserstein_metric) — minimal amount of work to transform one distribution into another, and [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity) — measure of how orientation and direction of vectors is closed."
@@ -66,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a3354458",
+   "id": "ca374bbe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d3f8083",
+   "id": "00609ce6",
    "metadata": {},
    "source": [
     "### 2. Bakends"
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "459e8278",
+   "id": "6c7477ee",
    "metadata": {},
    "source": [
     "Experiments will be conducted both in simulation and on QPU. Thus, it makes sense to create a separate class that \"unifies\" creation of new backend objects."
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "0002e677",
+   "id": "3e16c2c7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d77f681b",
+   "id": "62ad9db3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "0bb55a20",
+   "id": "1d6543a4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "bed9aa3a",
+   "id": "69625023",
    "metadata": {},
    "outputs": [
     {
@@ -171,16 +171,16 @@
      "output_type": "stream",
      "text": [
       "ibmq_qasm_simulator\t is online=True\twith a queue=0\n",
-      "ibmq_lima\t is online=True\twith a queue=360\n",
-      "ibmq_belem\t is online=True\twith a queue=198\n",
-      "ibmq_quito\t is online=True\twith a queue=171\n",
+      "ibmq_lima\t is online=True\twith a queue=369\n",
+      "ibmq_belem\t is online=True\twith a queue=193\n",
+      "ibmq_quito\t is online=True\twith a queue=162\n",
       "simulator_statevector\t is online=True\twith a queue=0\n",
       "simulator_mps\t is online=True\twith a queue=0\n",
       "simulator_extended_stabilizer\t is online=True\twith a queue=0\n",
       "simulator_stabilizer\t is online=True\twith a queue=0\n",
-      "ibmq_manila\t is online=True\twith a queue=150\n",
-      "ibm_nairobi\t is online=True\twith a queue=518\n",
-      "ibm_oslo\t is online=True\twith a queue=291\n"
+      "ibmq_manila\t is online=True\twith a queue=169\n",
+      "ibm_nairobi\t is online=True\twith a queue=517\n",
+      "ibm_oslo\t is online=True\twith a queue=272\n"
      ]
     }
    ],
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a949f9a",
+   "id": "e4c34450",
    "metadata": {},
    "source": [
     "### 3. Design single experiment"
@@ -204,7 +204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f46b211c",
+   "id": "a15288f7",
    "metadata": {},
    "source": [
     "Our experiment consists of several stages: \n",
@@ -218,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "3b127846",
+   "id": "5a7e4873",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +260,9 @@
     "        return qc\n",
     "    \n",
     "    def __apply(self, qc, data, shots):\n",
-    "        counts = execute(qc, self.backend_factory.get_new(), shots=shots).result().get_counts()\n",
+    "        backend = self.backend_factory.get_new()\n",
+    "        qc = transpile(qc, backend)\n",
+    "        counts = execute(qc, backend, shots=shots).result().get_counts()\n",
     "        dist = self.__get_dist(counts)\n",
     "        metrics = self.metrics.compute(data, dist)\n",
     "        return metrics\n",
@@ -282,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "17d237d8",
+   "id": "4b34b3ac",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cc72870",
+   "id": "f51b3a61",
    "metadata": {},
    "source": [
     "Let's run experiments both in simulator and QPU for sanity checking."
@@ -304,18 +306,18 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "3ff06323",
+   "id": "3ceebd62",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'initialize': {'mae': 0.05024141978999702,\n",
-       "  'wasserstein': 0.05024141978999702,\n",
-       "  'cosine_similarity': 0.9766157888828089},\n",
-       " 'isometry': {'mae': 0.04599171181240917,\n",
-       "  'wasserstein': 0.04599171181240917,\n",
-       "  'cosine_similarity': 0.9781958615695254}}"
+       "{'initialize': {'mae': 0.03305844983960471,\n",
+       "  'wasserstein': 0.03266759566687652,\n",
+       "  'cosine_similarity': 0.9874957555738519},\n",
+       " 'isometry': {'mae': 0.03630205271243242,\n",
+       "  'wasserstein': 0.03630205271243242,\n",
+       "  'cosine_similarity': 0.9856269918858531}}"
       ]
      },
      "execution_count": 9,
@@ -330,7 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "1c652d53",
+   "id": "652fea52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,18 +346,18 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "0aad5ca3",
+   "id": "041e06d9",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'initialize': {'mae': 0.10785674416916756,\n",
-       "  'wasserstein': 0.043570579953931085,\n",
-       "  'cosine_similarity': 0.8616847580089381},\n",
-       " 'isometry': {'mae': 0.04858586104847885,\n",
-       "  'wasserstein': 0.026298454958369636,\n",
-       "  'cosine_similarity': 0.9647688544399704}}"
+       "{'initialize': {'mae': 0.03302659681928792,\n",
+       "  'wasserstein': 0.028287252058731387,\n",
+       "  'cosine_similarity': 0.9820865188416839},\n",
+       " 'isometry': {'mae': 0.06614933643196075,\n",
+       "  'wasserstein': 0.06120029739837004,\n",
+       "  'cosine_similarity': 0.9565363554096502}}"
       ]
      },
      "execution_count": 11,
@@ -369,7 +371,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42f20e13",
+   "id": "9ee83b6c",
    "metadata": {},
    "source": [
     "### 4. Analyse multiple experiments"
@@ -377,7 +379,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51ccb7a8",
+   "id": "a37d2f5c",
    "metadata": {},
    "source": [
     "Processes in quantum computations are stochastic. So, in order to draw any conclusions, we should (at least try to) conduct multiple experiments. Frankly speaking, we might want to run experiments until the vector averaged over all iterations converges. Bad thing is that I don't have my own QPU yet :( , so we will wait a lot in a queue. Also, this approach inherit problems with floating-point arithmetic. Therefore, we will only focus on number of iterations (=experiments)."
@@ -385,8 +387,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "24f73108",
+   "execution_count": 15,
+   "id": "2282448d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,6 +405,7 @@
     "        metrics_dict_init = {m: list() for m in self.metrics_available}\n",
     "        metrics_dict_isom = {m: list() for m in self.metrics_available}\n",
     "        for i in range(self.iterations):\n",
+    "            print(i)\n",
     "            e = Experiment(\n",
     "                backend_factory=self.backend_factory,\n",
     "                n_qubits=self.n_qubits,\n",
@@ -434,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "086c4033",
+   "id": "900e4759",
    "metadata": {},
    "outputs": [
     {
@@ -443,13 +446,13 @@
      "text": [
       "Backend: qasm_simulator\n",
       "  'qc.initialise':\n",
-      "\tmae: 0.03956551 ± 0.00002130\n",
-      "\twasserstein: 0.03956195 ± 0.00002133\n",
-      "\tcosine_similarity: 0.96828348 ± 0.00004409\n",
+      "\tmae: 0.03937070 ± 0.00002271\n",
+      "\twasserstein: 0.03936723 ± 0.00002273\n",
+      "\tcosine_similarity: 0.96855378 ± 0.00004631\n",
       "  'qc.isometry':\n",
-      "\tmae: 0.03954220 ± 0.00002130\n",
-      "\twasserstein: 0.03953925 ± 0.00002132\n",
-      "\tcosine_similarity: 0.96830941 ± 0.00004432\n"
+      "\tmae: 0.03935132 ± 0.00002260\n",
+      "\twasserstein: 0.03934719 ± 0.00002263\n",
+      "\tcosine_similarity: 0.96855801 ± 0.00004630\n"
      ]
     }
    ],
@@ -465,23 +468,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "8ec22ac6",
+   "execution_count": null,
+   "id": "4ba6e79a",
    "metadata": {},
    "outputs": [
     {
-     "ename": "IBMQJobFailureError",
-     "evalue": "'Unable to retrieve result for job 633f2d96e212b0083bbeee11. Job has failed: Instruction not in basis gates: instruction: cx, qubits: [3, 4], params: []. Error code: 7000.'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mIBMQJobFailureError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn [14], line 7\u001b[0m\n\u001b[1;32m      1\u001b[0m inspector \u001b[38;5;241m=\u001b[39m Inspector(\n\u001b[1;32m      2\u001b[0m     backend_factory\u001b[38;5;241m=\u001b[39mIBMQpuFactory(),\n\u001b[1;32m      3\u001b[0m     n_qubits\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m5\u001b[39m, \n\u001b[1;32m      4\u001b[0m     shots\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m20000\u001b[39m, \n\u001b[1;32m      5\u001b[0m     iterations\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m10\u001b[39m\n\u001b[1;32m      6\u001b[0m )\n\u001b[0;32m----> 7\u001b[0m \u001b[43minspector\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "Cell \u001b[0;32mIn [12], line 19\u001b[0m, in \u001b[0;36mInspector.run\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mrange\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39miterations):\n\u001b[1;32m     14\u001b[0m     e \u001b[38;5;241m=\u001b[39m Experiment(\n\u001b[1;32m     15\u001b[0m         backend_factory\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mbackend_factory,\n\u001b[1;32m     16\u001b[0m         n_qubits\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_qubits,\n\u001b[1;32m     17\u001b[0m         shots\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mshots\n\u001b[1;32m     18\u001b[0m     )\n\u001b[0;32m---> 19\u001b[0m     e \u001b[38;5;241m=\u001b[39m \u001b[43me\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     21\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m m, v \u001b[38;5;129;01min\u001b[39;00m e[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124minitialize\u001b[39m\u001b[38;5;124m\"\u001b[39m]\u001b[38;5;241m.\u001b[39mitems():\n\u001b[1;32m     22\u001b[0m         metrics_dict_init[m]\u001b[38;5;241m.\u001b[39mappend(v)\n",
-      "Cell \u001b[0;32mIn [7], line 17\u001b[0m, in \u001b[0;36mExperiment.run\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     13\u001b[0m init_qc \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m__prepare_initialize_circuit(data)\n\u001b[1;32m     14\u001b[0m isom_qc \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m__prepare_isometry_circuit(data)\n\u001b[1;32m     16\u001b[0m result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mdict\u001b[39m(\n\u001b[0;32m---> 17\u001b[0m     initialize \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m__apply\u001b[49m\u001b[43m(\u001b[49m\u001b[43minit_qc\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdata\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshots\u001b[49m\u001b[43m)\u001b[49m,\n\u001b[1;32m     18\u001b[0m     isometry \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m__apply(isom_qc, data, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mshots)\n\u001b[1;32m     19\u001b[0m )\n\u001b[1;32m     20\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m result\n",
-      "Cell \u001b[0;32mIn [7], line 39\u001b[0m, in \u001b[0;36mExperiment.__apply\u001b[0;34m(self, qc, data, shots)\u001b[0m\n\u001b[1;32m     38\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__apply\u001b[39m(\u001b[38;5;28mself\u001b[39m, qc, data, shots):\n\u001b[0;32m---> 39\u001b[0m     counts \u001b[38;5;241m=\u001b[39m \u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43mqc\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbackend_factory\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_new\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mshots\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mshots\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresult\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241m.\u001b[39mget_counts()\n\u001b[1;32m     40\u001b[0m     dist \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m__get_dist(counts)\n\u001b[1;32m     41\u001b[0m     metrics \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmetrics\u001b[38;5;241m.\u001b[39mcompute(data, dist)\n",
-      "File \u001b[0;32m/opt/homebrew/Caskroom/miniforge/base/envs/quantum/lib/python3.9/site-packages/qiskit/providers/ibmq/job/ibmqjob.py:290\u001b[0m, in \u001b[0;36mIBMQJob.result\u001b[0;34m(self, timeout, wait, partial, refresh)\u001b[0m\n\u001b[1;32m    288\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    289\u001b[0m             error_message \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m error_message\n\u001b[0;32m--> 290\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m IBMQJobFailureError(\n\u001b[1;32m    291\u001b[0m             \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mUnable to retrieve result for job \u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[38;5;124m. Job has failed\u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mformat(\n\u001b[1;32m    292\u001b[0m                 \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mjob_id(), error_message))\n\u001b[1;32m    293\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    294\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_retrieve_result(refresh\u001b[38;5;241m=\u001b[39mrefresh)\n",
-      "\u001b[0;31mIBMQJobFailureError\u001b[0m: 'Unable to retrieve result for job 633f2d96e212b0083bbeee11. Job has failed: Instruction not in basis gates: instruction: cx, qubits: [3, 4], params: []. Error code: 7000.'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n"
      ]
     }
    ],
@@ -497,7 +492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd8753ee",
+   "id": "dfdb2ad7",
    "metadata": {},
    "source": [
     "### Discussion"
@@ -505,10 +500,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96a2917e",
+   "id": "9fe6810d",
    "metadata": {},
    "source": [
-    "Our results show that both methods are compatible in terms of MAE, Wasserstein metric and cosine similariy. Although, `.isometry()` gives a slightly better result. The reason is probably in the lower number of gates used and consequent beter fidelity of a state vector."
+    "Our results show that both methods are compatible in terms of MAE, Wasserstein metric and cosine similariy. Although, `.isometry()` gives a slightly better result. The reason is probably in the lower number of gates used and consequent beter fidelity of a state vector. \n",
+    "\n",
+    "Due to the fact that experiments take much time, I did not observe the relationship between number of qubits in use and metrics. Thus, I would assume that there is a linear dependency and results will be the same for lower number of qubits, albeit this is a topic for further study. "
    ]
   }
  ],

--- a/labs/202 Initialisation vs Isometry analysis.ipynb
+++ b/labs/202 Initialisation vs Isometry analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "1be88acf",
+   "id": "a785bb30",
    "metadata": {},
    "source": [
     "# Initialization vs Isometry in Qiskit"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9ca2af1",
+   "id": "904a2a57",
    "metadata": {},
    "source": [
     "According to `201 Tips and tricks.ipynb` there are exist two approaches to prepare the state: one was proposed by Shende, Bullock and Markov in [\"Synthesis of Quantum Logic Circuits\"](https://arxiv.org/abs/quant-ph/0406176) (2004) and another — by Iten et al. in [\"Quantum Circuits for Isometries\"](https://arxiv.org/abs/1501.06911) (2020). For more details please refer to correspondent notebook and original papers.\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "baa0112b",
+   "id": "ca100f92",
    "metadata": {},
    "source": [
     "### Prerequisites"
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "db4ad7af",
+   "id": "dd96ab60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,38 +46,110 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "30715b92",
+   "metadata": {},
+   "source": [
+    "### Metrics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c8e8b12",
+   "metadata": {},
+   "source": [
+    "Let's construct a class that will examine how emperical distribution is close to input vector in terms of [mean-absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error), [Wasserstein metric](https://en.wikipedia.org/wiki/Wasserstein_metric) and [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "be968bfb",
+   "id": "87760b34",
    "metadata": {},
    "outputs": [],
    "source": [
     "class Metrics:\n",
     "    \n",
     "    def __init__(self):\n",
-    "        self.metrics_available = [\"mse\", \"weierstrass\", \"cosine_similarity\"]\n",
+    "        self.metrics_available = [\"mae\", \"wasserstein\", \"cosine_similarity\"]\n",
     "    \n",
     "    def compute(self, data, dist):\n",
     "        metrics = dict(\n",
-    "            mse = np.square(data - dist).mean(),\n",
-    "            weierstrass = ws(data, dist),\n",
+    "            mae = np.abs(data - dist).mean(),\n",
+    "            wasserstein = ws(data, dist),\n",
     "            cosine_similarity = np.dot(data, dist) / (np.linalg.norm(data) * np.linalg.norm(dist))\n",
     "        )\n",
     "        return metrics"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "409a037b",
+   "metadata": {},
+   "source": [
+    "### Bakends"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5739d124",
+   "metadata": {},
+   "source": [
+    "We might want to use both simulation and real QPU for computation, so it makes sense to unify the interface of these."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "3ca98b02",
+   "id": "110f7782",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BackendFactory:\n",
+    "    \n",
+    "    def __init__(self):\n",
+    "        pass\n",
+    "    \n",
+    "    def get_new(self):\n",
+    "        pass\n",
+    "    \n",
+    "    def __str__(self):\n",
+    "        pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e304e29c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class QASMSimulatorFactory():\n",
+    "    \n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        pass\n",
+    "    \n",
+    "    def get_new(self):\n",
+    "        return BasicAer.get_backend('qasm_simulator')\n",
+    "    \n",
+    "    def __str__(self):\n",
+    "        return 'qasm_simulator'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9baf3fa6",
    "metadata": {},
    "outputs": [],
    "source": [
     "class Experiment:\n",
     "    \n",
-    "    def __init__(self, n_qubits=4, shots=65535):\n",
-    "        self.vector_size = 2 ** n_qubits\n",
+    "    def __init__(self, backend_factory, n_qubits=4, shots=65535):\n",
+    "        self.backend_factory = backend_factory\n",
     "        self.n = n_qubits\n",
+    "        self.vector_size = 2 ** n_qubits\n",
     "        self.shots = shots\n",
     "        self.metrics = Metrics()\n",
     "        \n",
@@ -110,7 +182,7 @@
     "        return qc\n",
     "    \n",
     "    def __apply(self, qc, data, shots):\n",
-    "        counts = execute(qc, BasicAer.get_backend('qasm_simulator'), shots=shots).result().get_counts()\n",
+    "        counts = execute(qc, self.backend_factory.get_new(), shots=shots).result().get_counts()\n",
     "        dist = self.__get_dist(counts)\n",
     "        metrics = self.metrics.compute(data, dist)\n",
     "        return metrics\n",
@@ -131,12 +203,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "a1003981",
+   "execution_count": 6,
+   "id": "afac049d",
    "metadata": {},
    "outputs": [],
    "source": [
     "experiment = Experiment(\n",
+    "    backend_factory=QASMSimulatorFactory(),\n",
     "    n_qubits=4, \n",
     "    shots=10000\n",
     ")"
@@ -144,22 +217,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "3925059e",
+   "execution_count": 7,
+   "id": "a0fe0d1f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'initialize': {'mse': 0.0061798472912882475,\n",
-       "  'weierstrass': 0.07025012693434898,\n",
-       "  'cosine_similarity': 0.950561221669694},\n",
-       " 'isometry': {'mse': 0.005925654619049145,\n",
-       "  'weierstrass': 0.06916523576196357,\n",
-       "  'cosine_similarity': 0.9525947630476069}}"
+       "{'initialize': {'mae': 0.04444438063046702,\n",
+       "  'wasserstein': 0.044444380630467024,\n",
+       "  'cosine_similarity': 0.981895760070583},\n",
+       " 'isometry': {'mae': 0.04389583423177455,\n",
+       "  'wasserstein': 0.04389583423177455,\n",
+       "  'cosine_similarity': 0.980759435140746}}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -169,15 +242,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b410f30a",
+   "metadata": {},
+   "source": [
+    "### Analyse multiple experiments"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "e2be6511",
+   "execution_count": 8,
+   "id": "a1cf1df6",
    "metadata": {},
    "outputs": [],
    "source": [
     "class Inspector:\n",
     "    \n",
-    "    def __init__(self, n_qubits=4, shots=65535, iterations=100):\n",
+    "    def __init__(self, backend_factory, n_qubits=4, shots=65535, iterations=100):\n",
+    "        self.backend_factory = backend_factory\n",
     "        self.n_qubits = n_qubits\n",
     "        self.shots = shots\n",
     "        self.iterations = iterations\n",
@@ -188,6 +270,7 @@
     "        metrics_dict_isom = {m: list() for m in self.metrics_available}\n",
     "        for i in range(self.iterations):\n",
     "            e = Experiment(\n",
+    "                backend_factory=self.backend_factory,\n",
     "                n_qubits=self.n_qubits,\n",
     "                shots=self.shots\n",
     "            )\n",
@@ -199,57 +282,52 @@
     "            for m, v in e[\"isometry\"].items():\n",
     "                metrics_dict_isom[m].append(v)\n",
     "        \n",
-    "        print(\"Statistics for 'qc.initialise':\")\n",
+    "        print(f\"Backend: {self.backend_factory}\")\n",
+    "        \n",
+    "        print(\"  'qc.initialise':\")\n",
     "        for m, v in metrics_dict_init.items():\n",
     "            v = np.array(v)\n",
-    "            print(f\"\\t{m}: {v.mean():.6f} ± {v.var():.6f}\")\n",
+    "            print(f\"\\t{m}: {v.mean():.8f} ± {v.var():.8f}\")\n",
     "        \n",
-    "        print(\"\\nStatistics for 'qc.isometry':\")\n",
+    "        print(\"  'qc.isometry':\")\n",
     "        for m, v in metrics_dict_isom.items():\n",
     "            v = np.array(v)\n",
-    "            print(f\"\\t{m}: {v.mean():.6f} ± {v.var():.6f}\")\n",
+    "            print(f\"\\t{m}: {v.mean():.8f} ± {v.var():.8f}\")\n",
     "         \n",
     "        "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "d4508c6a",
+   "execution_count": 9,
+   "id": "f8cb546f",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Statistics for 'qc.initialise':\n",
-      "\tmse: 0.001959 ± 0.000000\n",
-      "\tweierstrass: 0.039325 ± 0.000022\n",
-      "\tcosine_similarity: 0.968654 ± 0.000045\n",
-      "\n",
-      "Statistics for 'qc.isometry':\n",
-      "\tmse: 0.001960 ± 0.000000\n",
-      "\tweierstrass: 0.039337 ± 0.000022\n",
-      "\tcosine_similarity: 0.968641 ± 0.000045\n"
+      "Backend: qasm_simulator\n",
+      "  'qc.initialise':\n",
+      "\tmae: 0.04015251 ± 0.00002486\n",
+      "\twasserstein: 0.04014760 ± 0.00002484\n",
+      "\tcosine_similarity: 0.96653506 ± 0.00006403\n",
+      "  'qc.isometry':\n",
+      "\tmae: 0.04011296 ± 0.00002694\n",
+      "\twasserstein: 0.04011296 ± 0.00002694\n",
+      "\tcosine_similarity: 0.96639625 ± 0.00006414\n"
      ]
     }
    ],
    "source": [
     "inspector = Inspector(\n",
+    "    backend_factory=QASMSimulatorFactory(),\n",
     "    n_qubits=5, \n",
     "    shots=65535, \n",
-    "    iterations=1000\n",
+    "    iterations=10\n",
     ")\n",
     "inspector.run()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "38265095",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/labs/202 Initialisation vs Isometry analysis.ipynb
+++ b/labs/202 Initialisation vs Isometry analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a5dd0c63",
+   "id": "18aaece7",
    "metadata": {},
    "source": [
     "# Initialization vs Isometry in Qiskit"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b3b6c287",
+   "id": "17098f93",
    "metadata": {},
    "source": [
     "According to `201 Tips and tricks.ipynb` there are exist two approaches to prepare the state: one was proposed by Shende, Bullock and Markov in [\"Synthesis of Quantum Logic Circuits\"](https://arxiv.org/abs/quant-ph/0406176) (2004) and another — by Iten et al. in [\"Quantum Circuits for Isometries\"](https://arxiv.org/abs/1501.06911) (2020). For more details please refer to correspondent notebook and original papers.\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f6cc06d",
+   "id": "70a9f042",
    "metadata": {},
    "source": [
     "### Prerequisites"
@@ -29,59 +29,103 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "9c7a4e57",
+   "id": "ed997bb4",
    "metadata": {},
    "outputs": [],
    "source": [
     "import math\n",
     "import numpy as np\n",
+    "\n",
     "from qiskit import QuantumCircuit, BasicAer, execute, transpile\n",
-    "from scipy.stats import wasserstein_distance as ws"
+    "from scipy.stats import wasserstein_distance as ws\n",
+    "from numpy import dot\n",
+    "from numpy.linalg import norm\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "501d94bb",
+   "id": "dc594e04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Metrics:\n",
+    "    \n",
+    "    def __init__(self):\n",
+    "        pass\n",
+    "    \n",
+    "    def compute(self, data, dist):\n",
+    "        metrics = dict(\n",
+    "            mse = np.square(data - dist).mean(),\n",
+    "            weierstrass = ws(data, dist),\n",
+    "            cosine_similarity = np.dot(data, dist) / (np.linalg.norm(data) * np.linalg.norm(dist))\n",
+    "        )\n",
+    "        return metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d03f44f3",
    "metadata": {},
    "outputs": [],
    "source": [
     "class Experiment:\n",
     "    \n",
-    "    def __init__(self, vector_size=16):\n",
+    "    def __init__(self, vector_size=16, shots=100000):\n",
     "        message = \"Vector size should be power of 2\"\n",
     "        assert (vector_size & (vector_size-1) == 0) and vector_size != 0, message\n",
     "        \n",
     "        self.vector_size = vector_size\n",
     "        self.n = math.ceil(math.log(self.vector_size, 2))\n",
+    "        self.shots = shots\n",
+    "        self.metrics = Metrics()\n",
     "        \n",
-    "    def run(self, shots=10000):\n",
+    "    def run(self):\n",
     "        data = self.__get_random_vector()\n",
-    "        init_dict = self.__apply_initalize(data, shots)\n",
     "        \n",
+    "        init_qc = self.__prepare_initialize_circuit(data)\n",
+    "        isom_qc = self.__prepare_isometry_circuit(data)\n",
+    "\n",
     "        result = dict(\n",
-    "            init = init_dict,\n",
+    "            initialize = self.__apply(init_qc, data, self.shots),\n",
+    "            isometry = self.__apply(isom_qc, data, self.shots)\n",
     "        )\n",
     "        return result\n",
     "    \n",
-    "    def __apply_initalize(self, data, shots):\n",
+    "    def __prepare_initialize_circuit(self, data):\n",
     "        n = self.n\n",
+    "        range_n = range(n)\n",
     "        qc = QuantumCircuit(n, n)\n",
     "        qc.initialize(data)\n",
-    "        qc.measure(range(n), range(n))\n",
-    "        \n",
-    "        counts = execute(qc, BasicAer.get_backend('qasm_simulator'), shots=shots).result().get_counts()\n",
-    "        # TODO: sometimes number of elements there is less than vector_size (pad)\n",
-    "        dist = np.array([b for a,b in sorted(list(counts.items()), key = lambda x: x[0])]) \n",
-    "        dist = dist / np.linalg.norm(dist)\n",
-    "        \n",
-    "        metrics = dict(\n",
-    "            mse = np.square(data - dist).mean(),\n",
-    "            ws = ws(data, dist)\n",
-    "        )\n",
-    "        return metrics\n",
-    "        \n",
+    "        qc.measure(range_n, range_n)\n",
+    "        return qc\n",
     "    \n",
+    "    def __prepare_isometry_circuit(self, data):\n",
+    "        n = self.n\n",
+    "        range_n = range(n)\n",
+    "        qc = QuantumCircuit(n, n)\n",
+    "        qc.isometry(data, list(range_n), None)\n",
+    "        qc.measure(range_n, range_n)\n",
+    "        return qc\n",
+    "    \n",
+    "    def __apply(self, qc, data, shots):\n",
+    "        counts = execute(qc, BasicAer.get_backend('qasm_simulator'), shots=shots).result().get_counts()\n",
+    "        dist = self.__get_dist(counts)\n",
+    "        metrics = self.metrics.compute(data, dist)\n",
+    "        return metrics\n",
+    "    \n",
+    "    def __get_dist(self, counts):\n",
+    "        dist = [0. for i in range(self.vector_size)]\n",
+    "        for a, b in sorted(list(counts.items())):\n",
+    "            dist[int(a, 2)] = b\n",
+    "        dist = np.array(dist)\n",
+    "        dist = dist / np.linalg.norm(dist)\n",
+    "        return dist\n",
+    "        \n",
     "    def __get_random_vector(self):\n",
     "        a = np.random.rand(self.vector_size)\n",
     "        a = a / np.linalg.norm(a)\n",
@@ -90,27 +134,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "3b3a3ee7",
+   "execution_count": 4,
+   "id": "95f83fe5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment = Experiment(32)"
+    "experiment = Experiment(\n",
+    "    vector_size=16, \n",
+    "    shots=10000\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "4bc23cd7",
+   "execution_count": 5,
+   "id": "f4a89f3e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'init': {'mse': 0.0016230030811164708, 'ws': 0.03584424375870574}}"
+       "{'initialize': {'mse': 0.003475867536236607,\n",
+       "  'weierstrass': 0.04769451672356363,\n",
+       "  'cosine_similarity': 0.972193059710107},\n",
+       " 'isometry': {'mse': 0.0035561022951466335,\n",
+       "  'weierstrass': 0.04802210970295095,\n",
+       "  'cosine_similarity': 0.9715511816388269}}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -118,6 +170,14 @@
    "source": [
     "experiment.run()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "372b9b1f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/labs/202 Initialisation vs Isometry analysis.ipynb
+++ b/labs/202 Initialisation vs Isometry analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "18aaece7",
+   "id": "1be88acf",
    "metadata": {},
    "source": [
     "# Initialization vs Isometry in Qiskit"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17098f93",
+   "id": "e9ca2af1",
    "metadata": {},
    "source": [
     "According to `201 Tips and tricks.ipynb` there are exist two approaches to prepare the state: one was proposed by Shende, Bullock and Markov in [\"Synthesis of Quantum Logic Circuits\"](https://arxiv.org/abs/quant-ph/0406176) (2004) and another — by Iten et al. in [\"Quantum Circuits for Isometries\"](https://arxiv.org/abs/1501.06911) (2020). For more details please refer to correspondent notebook and original papers.\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70a9f042",
+   "id": "baa0112b",
    "metadata": {},
    "source": [
     "### Prerequisites"
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ed997bb4",
+   "id": "db4ad7af",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,14 +48,14 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "dc594e04",
+   "id": "be968bfb",
    "metadata": {},
    "outputs": [],
    "source": [
     "class Metrics:\n",
     "    \n",
     "    def __init__(self):\n",
-    "        pass\n",
+    "        self.metrics_available = [\"mse\", \"weierstrass\", \"cosine_similarity\"]\n",
     "    \n",
     "    def compute(self, data, dist):\n",
     "        metrics = dict(\n",
@@ -69,18 +69,15 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d03f44f3",
+   "id": "3ca98b02",
    "metadata": {},
    "outputs": [],
    "source": [
     "class Experiment:\n",
     "    \n",
-    "    def __init__(self, vector_size=16, shots=100000):\n",
-    "        message = \"Vector size should be power of 2\"\n",
-    "        assert (vector_size & (vector_size-1) == 0) and vector_size != 0, message\n",
-    "        \n",
-    "        self.vector_size = vector_size\n",
-    "        self.n = math.ceil(math.log(self.vector_size, 2))\n",
+    "    def __init__(self, n_qubits=4, shots=65535):\n",
+    "        self.vector_size = 2 ** n_qubits\n",
+    "        self.n = n_qubits\n",
     "        self.shots = shots\n",
     "        self.metrics = Metrics()\n",
     "        \n",
@@ -135,12 +132,12 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "95f83fe5",
+   "id": "a1003981",
    "metadata": {},
    "outputs": [],
    "source": [
     "experiment = Experiment(\n",
-    "    vector_size=16, \n",
+    "    n_qubits=4, \n",
     "    shots=10000\n",
     ")"
    ]
@@ -148,18 +145,18 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "f4a89f3e",
+   "id": "3925059e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'initialize': {'mse': 0.003475867536236607,\n",
-       "  'weierstrass': 0.04769451672356363,\n",
-       "  'cosine_similarity': 0.972193059710107},\n",
-       " 'isometry': {'mse': 0.0035561022951466335,\n",
-       "  'weierstrass': 0.04802210970295095,\n",
-       "  'cosine_similarity': 0.9715511816388269}}"
+       "{'initialize': {'mse': 0.0061798472912882475,\n",
+       "  'weierstrass': 0.07025012693434898,\n",
+       "  'cosine_similarity': 0.950561221669694},\n",
+       " 'isometry': {'mse': 0.005925654619049145,\n",
+       "  'weierstrass': 0.06916523576196357,\n",
+       "  'cosine_similarity': 0.9525947630476069}}"
       ]
      },
      "execution_count": 5,
@@ -173,8 +170,83 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
+   "id": "e2be6511",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Inspector:\n",
+    "    \n",
+    "    def __init__(self, n_qubits=4, shots=65535, iterations=100):\n",
+    "        self.n_qubits = n_qubits\n",
+    "        self.shots = shots\n",
+    "        self.iterations = iterations\n",
+    "        self.metrics_available = Metrics().metrics_available\n",
+    "    \n",
+    "    def run(self):\n",
+    "        metrics_dict_init = {m: list() for m in self.metrics_available}\n",
+    "        metrics_dict_isom = {m: list() for m in self.metrics_available}\n",
+    "        for i in range(self.iterations):\n",
+    "            e = Experiment(\n",
+    "                n_qubits=self.n_qubits,\n",
+    "                shots=self.shots\n",
+    "            )\n",
+    "            e = e.run()\n",
+    "            \n",
+    "            for m, v in e[\"initialize\"].items():\n",
+    "                metrics_dict_init[m].append(v)\n",
+    "                \n",
+    "            for m, v in e[\"isometry\"].items():\n",
+    "                metrics_dict_isom[m].append(v)\n",
+    "        \n",
+    "        print(\"Statistics for 'qc.initialise':\")\n",
+    "        for m, v in metrics_dict_init.items():\n",
+    "            v = np.array(v)\n",
+    "            print(f\"\\t{m}: {v.mean():.6f} ± {v.var():.6f}\")\n",
+    "        \n",
+    "        print(\"\\nStatistics for 'qc.isometry':\")\n",
+    "        for m, v in metrics_dict_isom.items():\n",
+    "            v = np.array(v)\n",
+    "            print(f\"\\t{m}: {v.mean():.6f} ± {v.var():.6f}\")\n",
+    "         \n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d4508c6a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Statistics for 'qc.initialise':\n",
+      "\tmse: 0.001959 ± 0.000000\n",
+      "\tweierstrass: 0.039325 ± 0.000022\n",
+      "\tcosine_similarity: 0.968654 ± 0.000045\n",
+      "\n",
+      "Statistics for 'qc.isometry':\n",
+      "\tmse: 0.001960 ± 0.000000\n",
+      "\tweierstrass: 0.039337 ± 0.000022\n",
+      "\tcosine_similarity: 0.968641 ± 0.000045\n"
+     ]
+    }
+   ],
+   "source": [
+    "inspector = Inspector(\n",
+    "    n_qubits=5, \n",
+    "    shots=65535, \n",
+    "    iterations=1000\n",
+    ")\n",
+    "inspector.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
-   "id": "372b9b1f",
+   "id": "38265095",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/labs/202 Initialisation vs Isometry analysis.ipynb
+++ b/labs/202 Initialisation vs Isometry analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a785bb30",
+   "id": "b236a439",
    "metadata": {},
    "source": [
     "# Initialization vs Isometry in Qiskit"
@@ -10,36 +10,38 @@
   },
   {
    "cell_type": "markdown",
-   "id": "904a2a57",
+   "id": "12e3b3b8",
    "metadata": {},
    "source": [
     "According to `201 Tips and tricks.ipynb` there are exist two approaches to prepare the state: one was proposed by Shende, Bullock and Markov in [\"Synthesis of Quantum Logic Circuits\"](https://arxiv.org/abs/quant-ph/0406176) (2004) and another — by Iten et al. in [\"Quantum Circuits for Isometries\"](https://arxiv.org/abs/1501.06911) (2020). For more details please refer to correspondent notebook and original papers.\n",
     "\n",
-    "This notebook concerns comparison of these two methods in terms of how close obtained states are to the desired vector. For someone who knows quantum programming inside out, the answer might appear trivial, but not for me..."
+    "This notebook concerns comparison of these two methods in terms of how close obtained states are to the desired vector. For someone who knows quantum programming inside out, the answer might appear trivial. Nevertheless, let's give it a try."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ca100f92",
+   "id": "e3f79a3a",
    "metadata": {},
    "source": [
-    "### Prerequisites"
+    "### 0. Prerequisites"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "dd96ab60",
+   "id": "30cf9e38",
    "metadata": {},
    "outputs": [],
    "source": [
     "import math\n",
     "import numpy as np\n",
     "\n",
-    "from qiskit import QuantumCircuit, BasicAer, execute, transpile\n",
+    "from qiskit import QuantumCircuit, BasicAer, execute, transpile, IBMQ\n",
     "from scipy.stats import wasserstein_distance as ws\n",
     "from numpy import dot\n",
     "from numpy.linalg import norm\n",
+    "\n",
+    "IBMQ.load_account()\n",
     "\n",
     "import warnings\n",
     "warnings.filterwarnings(\"ignore\")"
@@ -47,24 +49,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30715b92",
+   "id": "1dc83d7d",
    "metadata": {},
    "source": [
-    "### Metrics"
+    "### 1. Metrics"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1c8e8b12",
+   "id": "1758cdad",
    "metadata": {},
    "source": [
-    "Let's construct a class that will examine how emperical distribution is close to input vector in terms of [mean-absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error), [Wasserstein metric](https://en.wikipedia.org/wiki/Wasserstein_metric) and [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity)."
+    "Let's construct a class that will examine how emperical distribution is close to an input vector. Since, we operate with a arrays of numbers of a fixed length, we can consider them both as distributions and as vectors. Methods will be assessed in terms of [mean-absolute error](https://en.wikipedia.org/wiki/Mean_absolute_error), [Wasserstein metric](https://en.wikipedia.org/wiki/Wasserstein_metric) — minimal amount of work to transform one distribution into another, and [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity) — measure of how orientation and direction of vectors is closed."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "87760b34",
+   "id": "a3354458",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,24 +86,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "409a037b",
+   "id": "3d3f8083",
    "metadata": {},
    "source": [
-    "### Bakends"
+    "### 2. Bakends"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5739d124",
+   "id": "459e8278",
    "metadata": {},
    "source": [
-    "We might want to use both simulation and real QPU for computation, so it makes sense to unify the interface of these."
+    "Experiments will be conducted both in simulation and on QPU. Thus, it makes sense to create a separate class that \"unifies\" creation of new backend objects."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "110f7782",
+   "id": "0002e677",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,11 +122,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "e304e29c",
+   "id": "d77f681b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "class QASMSimulatorFactory():\n",
+    "class QASMSimulatorFactory(BackendFactory):\n",
     "    \n",
     "    def __init__(self):\n",
     "        super().__init__()\n",
@@ -140,7 +142,83 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "9baf3fa6",
+   "id": "0bb55a20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class IBMQpuFactory(BackendFactory):\n",
+    "    \n",
+    "    def __init__(self, name=\"ibmq_belem\"):\n",
+    "        super().__init__()\n",
+    "        self.provider = IBMQ.get_provider('ibm-q')\n",
+    "        self.name = name\n",
+    "    \n",
+    "    def get_new(self):\n",
+    "        return self.provider.get_backend(self.name)\n",
+    "    \n",
+    "    def __str__(self):\n",
+    "        return f'ibm-q {self.name}'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bed9aa3a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ibmq_qasm_simulator\t is online=True\twith a queue=0\n",
+      "ibmq_lima\t is online=True\twith a queue=360\n",
+      "ibmq_belem\t is online=True\twith a queue=198\n",
+      "ibmq_quito\t is online=True\twith a queue=171\n",
+      "simulator_statevector\t is online=True\twith a queue=0\n",
+      "simulator_mps\t is online=True\twith a queue=0\n",
+      "simulator_extended_stabilizer\t is online=True\twith a queue=0\n",
+      "simulator_stabilizer\t is online=True\twith a queue=0\n",
+      "ibmq_manila\t is online=True\twith a queue=150\n",
+      "ibm_nairobi\t is online=True\twith a queue=518\n",
+      "ibm_oslo\t is online=True\twith a queue=291\n"
+     ]
+    }
+   ],
+   "source": [
+    "provider = IBMQ.get_provider('ibm-q')\n",
+    "available_cloud_backends = provider.backends() \n",
+    "for backend in available_cloud_backends:\n",
+    "    status = backend.status()\n",
+    "    is_operational = status.operational\n",
+    "    jobs_in_queue = status.pending_jobs\n",
+    "    print(f\"{backend}\\t is online={is_operational}\\twith a queue={jobs_in_queue}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a949f9a",
+   "metadata": {},
+   "source": [
+    "### 3. Design single experiment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f46b211c",
+   "metadata": {},
+   "source": [
+    "Our experiment consists of several stages: \n",
+    "1. Prepare a random vector o size n\n",
+    "2. Create two quantum circuits with `.initialize()` and `.isometry()` methods\n",
+    "3. Execute quantum circuits\n",
+    "4. Measure the resultant distribution\n",
+    "5. Assess how close is this distribution to the desired one"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3b127846",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,12 +281,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "afac049d",
+   "execution_count": 8,
+   "id": "17d237d8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment = Experiment(\n",
+    "experiment_sim = Experiment(\n",
     "    backend_factory=QASMSimulatorFactory(),\n",
     "    n_qubits=4, \n",
     "    shots=10000\n",
@@ -216,43 +294,99 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2cc72870",
+   "metadata": {},
+   "source": [
+    "Let's run experiments both in simulator and QPU for sanity checking."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "a0fe0d1f",
+   "execution_count": 9,
+   "id": "3ff06323",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'initialize': {'mae': 0.04444438063046702,\n",
-       "  'wasserstein': 0.044444380630467024,\n",
-       "  'cosine_similarity': 0.981895760070583},\n",
-       " 'isometry': {'mae': 0.04389583423177455,\n",
-       "  'wasserstein': 0.04389583423177455,\n",
-       "  'cosine_similarity': 0.980759435140746}}"
+       "{'initialize': {'mae': 0.05024141978999702,\n",
+       "  'wasserstein': 0.05024141978999702,\n",
+       "  'cosine_similarity': 0.9766157888828089},\n",
+       " 'isometry': {'mae': 0.04599171181240917,\n",
+       "  'wasserstein': 0.04599171181240917,\n",
+       "  'cosine_similarity': 0.9781958615695254}}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "experiment.run()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b410f30a",
-   "metadata": {},
-   "source": [
-    "### Analyse multiple experiments"
+    "experiment_sim.run()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "a1cf1df6",
+   "execution_count": 10,
+   "id": "1c652d53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment_ibm = Experiment(\n",
+    "    backend_factory=IBMQpuFactory(),\n",
+    "    n_qubits=4, \n",
+    "    shots=20000 # max. number of shots for ibm-q\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "0aad5ca3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'initialize': {'mae': 0.10785674416916756,\n",
+       "  'wasserstein': 0.043570579953931085,\n",
+       "  'cosine_similarity': 0.8616847580089381},\n",
+       " 'isometry': {'mae': 0.04858586104847885,\n",
+       "  'wasserstein': 0.026298454958369636,\n",
+       "  'cosine_similarity': 0.9647688544399704}}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "experiment_ibm.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42f20e13",
+   "metadata": {},
+   "source": [
+    "### 4. Analyse multiple experiments"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51ccb7a8",
+   "metadata": {},
+   "source": [
+    "Processes in quantum computations are stochastic. So, in order to draw any conclusions, we should (at least try to) conduct multiple experiments. Frankly speaking, we might want to run experiments until the vector averaged over all iterations converges. Bad thing is that I don't have my own QPU yet :( , so we will wait a lot in a queue. Also, this approach inherit problems with floating-point arithmetic. Therefore, we will only focus on number of iterations (=experiments)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "24f73108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,8 +433,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "f8cb546f",
+   "execution_count": 13,
+   "id": "086c4033",
    "metadata": {},
    "outputs": [
     {
@@ -309,13 +443,13 @@
      "text": [
       "Backend: qasm_simulator\n",
       "  'qc.initialise':\n",
-      "\tmae: 0.04015251 ± 0.00002486\n",
-      "\twasserstein: 0.04014760 ± 0.00002484\n",
-      "\tcosine_similarity: 0.96653506 ± 0.00006403\n",
+      "\tmae: 0.03956551 ± 0.00002130\n",
+      "\twasserstein: 0.03956195 ± 0.00002133\n",
+      "\tcosine_similarity: 0.96828348 ± 0.00004409\n",
       "  'qc.isometry':\n",
-      "\tmae: 0.04011296 ± 0.00002694\n",
-      "\twasserstein: 0.04011296 ± 0.00002694\n",
-      "\tcosine_similarity: 0.96639625 ± 0.00006414\n"
+      "\tmae: 0.03954220 ± 0.00002130\n",
+      "\twasserstein: 0.03953925 ± 0.00002132\n",
+      "\tcosine_similarity: 0.96830941 ± 0.00004432\n"
      ]
     }
    ],
@@ -324,9 +458,57 @@
     "    backend_factory=QASMSimulatorFactory(),\n",
     "    n_qubits=5, \n",
     "    shots=65535, \n",
+    "    iterations=1000\n",
+    ")\n",
+    "inspector.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "8ec22ac6",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "IBMQJobFailureError",
+     "evalue": "'Unable to retrieve result for job 633f2d96e212b0083bbeee11. Job has failed: Instruction not in basis gates: instruction: cx, qubits: [3, 4], params: []. Error code: 7000.'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIBMQJobFailureError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn [14], line 7\u001b[0m\n\u001b[1;32m      1\u001b[0m inspector \u001b[38;5;241m=\u001b[39m Inspector(\n\u001b[1;32m      2\u001b[0m     backend_factory\u001b[38;5;241m=\u001b[39mIBMQpuFactory(),\n\u001b[1;32m      3\u001b[0m     n_qubits\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m5\u001b[39m, \n\u001b[1;32m      4\u001b[0m     shots\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m20000\u001b[39m, \n\u001b[1;32m      5\u001b[0m     iterations\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m10\u001b[39m\n\u001b[1;32m      6\u001b[0m )\n\u001b[0;32m----> 7\u001b[0m \u001b[43minspector\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn [12], line 19\u001b[0m, in \u001b[0;36mInspector.run\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mrange\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39miterations):\n\u001b[1;32m     14\u001b[0m     e \u001b[38;5;241m=\u001b[39m Experiment(\n\u001b[1;32m     15\u001b[0m         backend_factory\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mbackend_factory,\n\u001b[1;32m     16\u001b[0m         n_qubits\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mn_qubits,\n\u001b[1;32m     17\u001b[0m         shots\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mshots\n\u001b[1;32m     18\u001b[0m     )\n\u001b[0;32m---> 19\u001b[0m     e \u001b[38;5;241m=\u001b[39m \u001b[43me\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     21\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m m, v \u001b[38;5;129;01min\u001b[39;00m e[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124minitialize\u001b[39m\u001b[38;5;124m\"\u001b[39m]\u001b[38;5;241m.\u001b[39mitems():\n\u001b[1;32m     22\u001b[0m         metrics_dict_init[m]\u001b[38;5;241m.\u001b[39mappend(v)\n",
+      "Cell \u001b[0;32mIn [7], line 17\u001b[0m, in \u001b[0;36mExperiment.run\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     13\u001b[0m init_qc \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m__prepare_initialize_circuit(data)\n\u001b[1;32m     14\u001b[0m isom_qc \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m__prepare_isometry_circuit(data)\n\u001b[1;32m     16\u001b[0m result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mdict\u001b[39m(\n\u001b[0;32m---> 17\u001b[0m     initialize \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m__apply\u001b[49m\u001b[43m(\u001b[49m\u001b[43minit_qc\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdata\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mshots\u001b[49m\u001b[43m)\u001b[49m,\n\u001b[1;32m     18\u001b[0m     isometry \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m__apply(isom_qc, data, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mshots)\n\u001b[1;32m     19\u001b[0m )\n\u001b[1;32m     20\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m result\n",
+      "Cell \u001b[0;32mIn [7], line 39\u001b[0m, in \u001b[0;36mExperiment.__apply\u001b[0;34m(self, qc, data, shots)\u001b[0m\n\u001b[1;32m     38\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__apply\u001b[39m(\u001b[38;5;28mself\u001b[39m, qc, data, shots):\n\u001b[0;32m---> 39\u001b[0m     counts \u001b[38;5;241m=\u001b[39m \u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43mqc\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbackend_factory\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_new\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mshots\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mshots\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mresult\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241m.\u001b[39mget_counts()\n\u001b[1;32m     40\u001b[0m     dist \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m__get_dist(counts)\n\u001b[1;32m     41\u001b[0m     metrics \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmetrics\u001b[38;5;241m.\u001b[39mcompute(data, dist)\n",
+      "File \u001b[0;32m/opt/homebrew/Caskroom/miniforge/base/envs/quantum/lib/python3.9/site-packages/qiskit/providers/ibmq/job/ibmqjob.py:290\u001b[0m, in \u001b[0;36mIBMQJob.result\u001b[0;34m(self, timeout, wait, partial, refresh)\u001b[0m\n\u001b[1;32m    288\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    289\u001b[0m             error_message \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m error_message\n\u001b[0;32m--> 290\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m IBMQJobFailureError(\n\u001b[1;32m    291\u001b[0m             \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mUnable to retrieve result for job \u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[38;5;124m. Job has failed\u001b[39m\u001b[38;5;132;01m{}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;241m.\u001b[39mformat(\n\u001b[1;32m    292\u001b[0m                 \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mjob_id(), error_message))\n\u001b[1;32m    293\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    294\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_retrieve_result(refresh\u001b[38;5;241m=\u001b[39mrefresh)\n",
+      "\u001b[0;31mIBMQJobFailureError\u001b[0m: 'Unable to retrieve result for job 633f2d96e212b0083bbeee11. Job has failed: Instruction not in basis gates: instruction: cx, qubits: [3, 4], params: []. Error code: 7000.'"
+     ]
+    }
+   ],
+   "source": [
+    "inspector = Inspector(\n",
+    "    backend_factory=IBMQpuFactory(),\n",
+    "    n_qubits=5, \n",
+    "    shots=20000, \n",
     "    iterations=10\n",
     ")\n",
     "inspector.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd8753ee",
+   "metadata": {},
+   "source": [
+    "### Discussion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96a2917e",
+   "metadata": {},
+   "source": [
+    "Our results show that both methods are compatible in terms of MAE, Wasserstein metric and cosine similariy. Although, `.isometry()` gives a slightly better result. The reason is probably in the lower number of gates used and consequent beter fidelity of a state vector."
    ]
   }
  ],


### PR DESCRIPTION
Created a python notebook comparing `.initialize` and `.isometry` in terms of MAE, Wasserstein distance, and cosine similarity. As a backend there were used `qasm_simulator` and `ibmq_belem`. Results show that in average `.isometry` performs better than its rival.